### PR TITLE
Change iterations to 2**42

### DIFF
--- a/src/bin/compute.rs
+++ b/src/bin/compute.rs
@@ -12,7 +12,7 @@ fn main() {
     let stdin = io::stdin();
     let handle = stdin.lock();
     let count = 1024;
-    let iterations = (1 << 25) / count;
+    let iterations = (1 << 42) / count;
     let mut seed = decode_hex(handle.lines().next().unwrap());
     println!("{}", hex::encode(&seed));
     for _ in 0..count {


### PR DESCRIPTION
This change is in line with the number of iterations we use to apply to the VDF output for Semaphore's trusted setup.